### PR TITLE
Fix typos in the project and PropTypes' import

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ yarn start (or npm start)
         └── index.html     # HTML for entry file
     ├── application.js     # Provider file
     ├── constants.js       # Constants
-    ├── index.js           # Enry file
+    ├── index.js           # Entry file
     └── theme.js           # Theme configuration for Antd
 ├── .editorconfig          #
 ├── .eslintrc              # Eslint config

--- a/src/views/components/empty-content.jsx
+++ b/src/views/components/empty-content.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Icon } from 'antd';
 
 const styles = {

--- a/src/views/containers/home.jsx
+++ b/src/views/containers/home.jsx
@@ -24,7 +24,7 @@ const style = {
 const Home = ({ notify, message, percent, increment, decrement }) => (
   <EmptyContent
     title="Start Application"
-    description="Wellcome to startkit application"
+    description="Welcome to the startkit application"
     icon="poweroff"
   >
     <div style={style.container}>


### PR DESCRIPTION
I fixed two typos, as described in the #5, but I also fixed the PropTypes' import, since the project was updated to React 16 and PropTypes doesn't belong to the `react` package anymore.